### PR TITLE
win64 fixes

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -2862,11 +2862,11 @@ PHP_MINFO_FUNCTION(imagick)
 	smart_str formats = {0};
 
 	char **supported_formats, *buffer;
-	size_t num_formats = 0, i;
+	MagickSizeType num_formats = 0, i;
 	size_t version_number;
 
 	supported_formats = MagickQueryFormats("*", &num_formats);
-	spprintf(&buffer, 0, "%zd", num_formats);
+	spprintf(&buffer, 0, MagickSizeFormat, num_formats);
 
 	php_info_print_table_start();
 	php_info_print_table_header(2, "imagick module", "enabled");

--- a/imagick.c
+++ b/imagick.c
@@ -2866,7 +2866,7 @@ PHP_MINFO_FUNCTION(imagick)
 	size_t version_number;
 
 	supported_formats = MagickQueryFormats("*", &num_formats);
-	spprintf(&buffer, 0, "%ld", num_formats);
+	spprintf(&buffer, 0, "%zd", num_formats);
 
 	php_info_print_table_start();
 	php_info_print_table_header(2, "imagick module", "enabled");

--- a/imagick.c
+++ b/imagick.c
@@ -2862,7 +2862,7 @@ PHP_MINFO_FUNCTION(imagick)
 	smart_str formats = {0};
 
 	char **supported_formats, *buffer;
-	unsigned long num_formats = 0, i;
+	size_t num_formats = 0, i;
 	size_t version_number;
 
 	supported_formats = MagickQueryFormats("*", &num_formats);

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -433,7 +433,7 @@ PHP_METHOD(imagick, shadeimage)
 PHP_METHOD(imagick, getsizeoffset)
 {
 	php_imagick_object *intern;
-	long offset;
+	size_t offset;
 	MagickBooleanType status;
 
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -1201,7 +1201,7 @@ PHP_METHOD(imagick, getimageproperties)
 	zend_bool values = 1;
 	char *pattern = "*", **properties, *property;
 	int pattern_len;
-	unsigned long properties_count, i;
+	size_t properties_count, i;
 	php_imagick_object *intern;
 
 	/* Parse parameters given to function */
@@ -1250,7 +1250,7 @@ PHP_METHOD(imagick, getimageprofiles)
 	zend_bool values = 1;
 	char *pattern = "*", **profiles, *profile;
 	int pattern_len;
-	unsigned long profiles_count, i;
+	size_t profiles_count, i;
 	php_imagick_object *intern;
 	size_t length;
 
@@ -3005,7 +3005,7 @@ PHP_METHOD(imagick, count)
 PHP_METHOD(imagick, queryformats)
 {
 	char **supported_formats;
-	unsigned long num_formats = 0, i;
+	size_t num_formats = 0, i;
 	char *pattern = "*";
 	int pattern_len = 1;
 
@@ -3032,7 +3032,7 @@ PHP_METHOD(imagick, queryformats)
 PHP_METHOD(imagick, queryfonts)
 {
 	char **fonts;
-	unsigned long num_fonts = 0, i;
+	size_t num_fonts = 0, i;
 	char *pattern = "*";
 	int pattern_len = 1;
 
@@ -5938,7 +5938,7 @@ PHP_METHOD(imagick, getimagechannelextrema)
 {
 	php_imagick_object *intern;
 	long channel_type;
-	unsigned long minima, maxima;
+	size_t minima, maxima;
 	MagickBooleanType status;
 
 	IMAGICK_METHOD_DEPRECATED ("Imagick", "getImageChannelExtrema");
@@ -6211,7 +6211,7 @@ PHP_METHOD(imagick, getimagedistortion)
 PHP_METHOD(imagick, getimageextrema)
 {
 	php_imagick_object *intern;
-	unsigned long min, max;
+	size_t min, max;
 	MagickBooleanType status;
 
 	IMAGICK_METHOD_DEPRECATED ("Imagick", "getImageExtrema");
@@ -6343,8 +6343,7 @@ PHP_METHOD(imagick, getimagehistogram)
 	php_imagick_object *intern;
 	php_imagickpixel_object *internp;
 	PixelWand **wand_array;
-	unsigned long colors = 0;
-	unsigned long i;
+	size_t colors = 0, i;
 	zval *tmp_pixelwand;
 
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -6464,8 +6463,8 @@ PHP_METHOD(imagick, getimagepage)
 {
 	php_imagick_object *intern;
 	MagickBooleanType status;
-	unsigned long width, height;
-	long x, y;
+	size_t width, height;
+	ssize_t x, y;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10291,8 +10290,8 @@ PHP_METHOD(imagick, getpage)
 {
 	php_imagick_object *intern;
 	MagickBooleanType status;
-	unsigned long width, height;
-	long x, y;
+	size_t width, height;
+	ssize_t x, y;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10322,7 +10321,7 @@ PHP_METHOD(imagick, getpage)
 PHP_METHOD(imagick, getquantumdepth)
 {
 	const char *quantum_depth;
-	unsigned long depth;
+	size_t depth;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10344,7 +10343,7 @@ PHP_METHOD(imagick, getquantumdepth)
 PHP_METHOD(imagick, getquantumrange)
 {
 	const char *quantum_range;
-	unsigned long range;
+	size_t range;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10413,7 +10412,7 @@ PHP_METHOD(imagick, getsamplingfactors)
 {
 	php_imagick_object *intern;
 	double *sampling_factors;
-	unsigned long number_factors = 0, i;
+	size_t number_factors = 0, i;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10439,7 +10438,7 @@ PHP_METHOD(imagick, getsamplingfactors)
 PHP_METHOD(imagick, getsize)
 {
 	php_imagick_object *intern;
-	unsigned long columns, rows;
+	size_t columns, rows;
 	MagickBooleanType status;
 
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -10687,7 +10686,7 @@ PHP_METHOD(imagick, setpage)
 {
 	php_imagick_object *intern;
 	MagickBooleanType status;
-	long width, height, x, y;
+	size_t width, height, x, y;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &width, &height, &x, &y) == FAILURE) {

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -433,7 +433,7 @@ PHP_METHOD(imagick, shadeimage)
 PHP_METHOD(imagick, getsizeoffset)
 {
 	php_imagick_object *intern;
-	size_t offset;
+	MagickSizeType offset;
 	MagickBooleanType status;
 
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -1201,7 +1201,7 @@ PHP_METHOD(imagick, getimageproperties)
 	zend_bool values = 1;
 	char *pattern = "*", **properties, *property;
 	int pattern_len;
-	size_t properties_count, i;
+	MagickSizeType properties_count, i;
 	php_imagick_object *intern;
 
 	/* Parse parameters given to function */
@@ -1250,7 +1250,7 @@ PHP_METHOD(imagick, getimageprofiles)
 	zend_bool values = 1;
 	char *pattern = "*", **profiles, *profile;
 	int pattern_len;
-	size_t profiles_count, i;
+	MagickSizeType profiles_count, i;
 	php_imagick_object *intern;
 	size_t length;
 
@@ -3005,7 +3005,7 @@ PHP_METHOD(imagick, count)
 PHP_METHOD(imagick, queryformats)
 {
 	char **supported_formats;
-	size_t num_formats = 0, i;
+	MagickSizeType num_formats = 0, i;
 	char *pattern = "*";
 	int pattern_len = 1;
 
@@ -3032,7 +3032,7 @@ PHP_METHOD(imagick, queryformats)
 PHP_METHOD(imagick, queryfonts)
 {
 	char **fonts;
-	size_t num_fonts = 0, i;
+	MagickSizeType num_fonts = 0, i;
 	char *pattern = "*";
 	int pattern_len = 1;
 
@@ -5938,7 +5938,7 @@ PHP_METHOD(imagick, getimagechannelextrema)
 {
 	php_imagick_object *intern;
 	long channel_type;
-	size_t minima, maxima;
+	MagickSizeType minima, maxima;
 	MagickBooleanType status;
 
 	IMAGICK_METHOD_DEPRECATED ("Imagick", "getImageChannelExtrema");
@@ -6212,7 +6212,7 @@ PHP_METHOD(imagick, getimagedistortion)
 PHP_METHOD(imagick, getimageextrema)
 {
 	php_imagick_object *intern;
-	size_t min, max;
+	MagickSizeType min, max;
 	MagickBooleanType status;
 
 	IMAGICK_METHOD_DEPRECATED ("Imagick", "getImageExtrema");
@@ -6344,7 +6344,7 @@ PHP_METHOD(imagick, getimagehistogram)
 	php_imagick_object *intern;
 	php_imagickpixel_object *internp;
 	PixelWand **wand_array;
-	size_t colors = 0, i;
+	MagickSizeType colors = 0, i;
 	zval *tmp_pixelwand;
 
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -6464,8 +6464,8 @@ PHP_METHOD(imagick, getimagepage)
 {
 	php_imagick_object *intern;
 	MagickBooleanType status;
-	size_t width, height;
-	ssize_t x, y;
+	MagickSizeType width, height;
+	MagickSizeType x, y;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -7314,8 +7314,10 @@ static
 zend_bool s_image_has_format (MagickWand *magick_wand)
 {
 	char *buffer;
+	zend_bool ret;
+
 	buffer = MagickGetImageFormat(magick_wand);
-	zend_bool ret = buffer && *buffer != '\0';
+	ret = buffer && *buffer != '\0';
 	if (buffer) {
 		MagickRelinquishMemory (buffer);
 	}
@@ -10293,8 +10295,8 @@ PHP_METHOD(imagick, getpage)
 {
 	php_imagick_object *intern;
 	MagickBooleanType status;
-	size_t width, height;
-	ssize_t x, y;
+	MagickSizeType width, height;
+	MagickSizeType x, y;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10324,7 +10326,7 @@ PHP_METHOD(imagick, getpage)
 PHP_METHOD(imagick, getquantumdepth)
 {
 	const char *quantum_depth;
-	size_t depth;
+	MagickSizeType depth;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10346,7 +10348,7 @@ PHP_METHOD(imagick, getquantumdepth)
 PHP_METHOD(imagick, getquantumrange)
 {
 	const char *quantum_range;
-	size_t range;
+	MagickSizeType range;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10415,7 +10417,7 @@ PHP_METHOD(imagick, getsamplingfactors)
 {
 	php_imagick_object *intern;
 	double *sampling_factors;
-	size_t number_factors = 0, i;
+	MagickSizeType number_factors = 0, i;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -10443,7 +10445,7 @@ PHP_METHOD(imagick, getsamplingfactors)
 PHP_METHOD(imagick, getsize)
 {
 	php_imagick_object *intern;
-	size_t columns, rows;
+	MagickSizeType columns, rows;
 	MagickBooleanType status;
 
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -10691,7 +10693,7 @@ PHP_METHOD(imagick, setpage)
 {
 	php_imagick_object *intern;
 	MagickBooleanType status;
-	size_t width, height, x, y;
+	MagickSizeType width, height, x, y;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &width, &height, &x, &y) == FAILURE) {

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -253,7 +253,7 @@ zend_bool php_imagick_check_font(char *font, int font_len TSRMLS_DC)
 {
 	zend_bool retval = 0;
 	char **fonts;
-	size_t num_fonts = 0, i = 0;
+	MagickSizeType num_fonts = 0, i = 0;
 
 	/* Check that user is only able to set a proper font */
 	fonts = MagickQueryFonts("*", &num_fonts);

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -253,7 +253,7 @@ zend_bool php_imagick_check_font(char *font, int font_len TSRMLS_DC)
 {
 	zend_bool retval = 0;
 	char **fonts;
-	unsigned long num_fonts = 0, i = 0;
+	size_t num_fonts = 0, i = 0;
 
 	/* Check that user is only able to set a proper font */
 	fonts = MagickQueryFonts("*", &num_fonts);

--- a/imagickdraw_class.c
+++ b/imagickdraw_class.c
@@ -1525,7 +1525,7 @@ PHP_METHOD(imagickdraw, getstrokedasharray)
 {
 	php_imagickdraw_object *internd;
 	double *stroke_array;
-	size_t num_elements, i;
+	MagickSizeType num_elements, i;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;

--- a/imagickdraw_class.c
+++ b/imagickdraw_class.c
@@ -1525,7 +1525,7 @@ PHP_METHOD(imagickdraw, getstrokedasharray)
 {
 	php_imagickdraw_object *internd;
 	double *stroke_array;
-	unsigned long num_elements, i;
+	size_t num_elements, i;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;

--- a/imagickpixeliterator_class.c
+++ b/imagickpixeliterator_class.c
@@ -452,7 +452,7 @@ PHP_METHOD(imagickpixeliterator, getpreviousiteratorrow)
 {
 	php_imagickpixeliterator_object *internpix;
 	PixelWand **wand_array;
-	size_t num_wands;
+	MagickSizeType num_wands;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -490,7 +490,7 @@ PHP_METHOD(imagickpixeliterator, getcurrentiteratorrow)
 {
 	php_imagickpixeliterator_object *internpix;
 	PixelWand **wand_array;
-	size_t num_wands;
+	MagickSizeType num_wands;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -531,7 +531,7 @@ PHP_METHOD(imagickpixeliterator, getnextiteratorrow)
 {
 	php_imagickpixeliterator_object *internpix;
 	PixelWand **wand_array;
-	size_t num_wands;
+	MagickSizeType num_wands;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;

--- a/imagickpixeliterator_class.c
+++ b/imagickpixeliterator_class.c
@@ -452,7 +452,7 @@ PHP_METHOD(imagickpixeliterator, getpreviousiteratorrow)
 {
 	php_imagickpixeliterator_object *internpix;
 	PixelWand **wand_array;
-	unsigned long num_wands;
+	size_t num_wands;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -490,7 +490,7 @@ PHP_METHOD(imagickpixeliterator, getcurrentiteratorrow)
 {
 	php_imagickpixeliterator_object *internpix;
 	PixelWand **wand_array;
-	unsigned long num_wands;
+	size_t num_wands;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -531,7 +531,7 @@ PHP_METHOD(imagickpixeliterator, getnextiteratorrow)
 {
 	php_imagickpixeliterator_object *internpix;
 	PixelWand **wand_array;
-	unsigned long num_wands;
+	size_t num_wands;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;


### PR DESCRIPTION
The current situation is that long is passed by ref to the signatures where size_t or ssize_t in ImageMagick is expected. That works fine so far on 32 bit everywhere and on 64 bit *nix. win64 is the one which can't take it, as long is 32 bit there while size_t is 64 bit. I'm aware that this patch can theoretically cause overflow when returning long, but ... that's actually impossible, like say getting supported formats I'm even not sure it'll exceed int16 range some when. When unsure, one can add explicit cast to long at the places where the data is returned, but passing long instead of size_t by ref is definitely crashy on win64.