### PR TITLE
Only use pkg-config to detect imagemagick libs

### DIFF
--- a/imagemagick.m4
+++ b/imagemagick.m4
@@ -1,11 +1,7 @@
 #########################################################
-# Locate ImageMagick configuration program
-# ImageMagick has the config program:
-# bin/Wand-config
-# bin/MagickWand-config
+# Locate ImageMagick
 #
 # Sets
-#  IM_WAND_BINARY
 #  IM_IMAGEMAGICK_PREFIX
 #  IM_IMAGEMAGICK_VERSION
 #  IM_IMAGEMAGICK_VERSION_MASK
@@ -35,49 +31,12 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
 
   AC_MSG_CHECKING(ImageMagick MagickWand API configuration program)
 
-  if test "$IM_EXTRA_SEARCH_PREFIX" != "yes"; then
-    for i in "$IM_EXTRA_SEARCH_PREFIX" /usr/local /usr /opt /opt/local;
-    do
-      if test -r "${i}/bin/MagickWand-config"; then
-        IM_WAND_BINARY="${i}/bin/MagickWand-config"
-        IM_IMAGEMAGICK_PREFIX=$i
-        break
-      fi
-
-      if test -r "${i}/bin/Wand-config"; then
-        IM_WAND_BINARY="${i}/bin/Wand-config"
-        IM_IMAGEMAGICK_PREFIX=$i
-        break
-      fi
-    done
-  else
-    for i in /usr/local /usr /opt /opt/local;
-    do
-      if test -r "${i}/bin/MagickWand-config"; then
-        IM_WAND_BINARY="${i}/bin/MagickWand-config"
-        IM_IMAGEMAGICK_PREFIX=$i
-        break
-      fi
-
-      if test -r "${i}/bin/Wand-config"; then
-        IM_WAND_BINARY="${i}/bin/Wand-config"
-        IM_IMAGEMAGICK_PREFIX=$i
-        break
-      fi
-    done
-  fi
-
-  if test "x" = "x$IM_WAND_BINARY"; then
-    AC_MSG_ERROR(not found. Please provide a path to MagickWand-config or Wand-config program.)
-  fi
-  AC_MSG_RESULT([found in $IM_WAND_BINARY])
-
 # This is used later for cflags and libs
   export PKG_CONFIG_PATH="${IM_IMAGEMAGICK_PREFIX}/${PHP_LIBDIR}/pkgconfig"
   
 # Check version
 #
-  IM_IMAGEMAGICK_VERSION=`$IM_WAND_BINARY --version`
+  IM_IMAGEMAGICK_VERSION=`$PKG_CONFIG --modversion MagickWand`
   IM_IMAGEMAGICK_VERSION_MASK=`echo $IM_IMAGEMAGICK_VERSION | $AWK 'BEGIN { FS = "."; } { printf "%d", ($[1] * 1000 + $[2]) * 1000 + $[3];}'`
 
   IM_MIMIMUM_VERSION_MASK=`echo $IM_MINIMUM_VERSION | $AWK 'BEGIN { FS = "."; } { printf "%d", ($[1] * 1000 + $[2]) * 1000 + $[3];}'`
@@ -97,7 +56,7 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
 
   AC_MSG_CHECKING(for MagickWand.h or magick-wand.h header)
 
-  IM_PREFIX=`$IM_WAND_BINARY --prefix`
+  IM_PREFIX=`$PKG_CONFIG --variable=prefix MagickWand`
   IM_MAJOR_VERSION=`echo $IM_IMAGEMAGICK_VERSION | $AWK 'BEGIN { FS = "."; } {print $[1]}'`
 
   # Try the header formats from newest to oldest
@@ -140,11 +99,10 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
 #
 # The cflags and libs
 #
-  IM_IMAGEMAGICK_LIBS=`$IM_WAND_BINARY --libs`
-  IM_IMAGEMAGICK_CFLAGS=`$IM_WAND_BINARY --cflags`
+  IM_IMAGEMAGICK_LIBS=`$PKG_CONFIG --libs MagickWand`
+  IM_IMAGEMAGICK_CFLAGS=`$PKG_CONFIG --cflags MagickWand`
 
   export IM_IMAGEMAGICK_PREFIX
-  export IM_WAND_BINARY
   export IM_IMAGEMAGICK_VERSION
   export IM_IMAGEMAGICK_VERSION_MASK
   export IM_INCLUDE_FORMAT


### PR DESCRIPTION
As Debian remove Magick-config shell script (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=761927, http://anonscm.debian.org/cgit/collab-maint/imagemagick.git/tree/debian/NEWS?h=debian/6.8.9.9-2), i propose to only use pkg-config to detect imagemagick libraries.

Original patch included in Debian package here : http://anonscm.debian.org/cgit/pkg-php/php-imagick.git/plain/debian/patches/imagemagick_pkgconfig_detection.patch