### PR TITLE
Added test for bug 59378, where writing to memory fails.

### DIFF
--- a/tests/bug59378.phpt
+++ b/tests/bug59378.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test PHP bug #59378 writing to php://memory is incomplete
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$imagick = new Imagick();
+$imagick->newPseudoImage(640, 480, "LOGO:");
+$imagick->setFormat("png");
+
+$fp = fopen("php://memory", 'r+');
+$imagick->writeImageFile($fp);
+rewind($fp);
+$memoryBlob = stream_get_contents($fp);
+fclose($fp);
+
+//This test depends on getImageBlob working correctly.
+$imageBlob = $imagick->getImageBlob();
+
+//Read the images from the data blobs.
+$imageReopened = new Imagick();
+$imageReopened->readImageBlob($imageBlob);
+$memoryReopened = new Imagick();
+$memoryReopened->readImageBlob($memoryBlob);
+
+//Compare to see if they are identical.
+$result = $imageReopened->compareImages($memoryReopened, \Imagick::METRIC_MEANABSOLUTEERROR);
+
+if ($result[1] == 0) {
+    echo "Reopened images are identical.";
+}
+else {
+    echo "Error, reopened images have changed.";
+}
+
+?>
+--EXPECTF--
+Reopened images are identical.


### PR DESCRIPTION
Hi @mkoppanen,

Can you review and merge this test?

It says on https://bugs.php.net/bug.php?id=59378 that you were able to reproduce this issue....I am not able to, and the issue was reported on a no longer supported version of PHP.

If you can't repro the issue any longer, I think we can safely close the bug.

cheers
Dan
