### PR TITLE
Added access to the get/set registry functions.

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -1364,6 +1364,15 @@ PHP_IMAGICK_API zend_class_entry *php_imagickpixel_get_class_entry()
 	ZEND_END_ARG_INFO()
 #endif
 
+	ZEND_BEGIN_ARG_INFO_EX(imagick_setregistry_args, 0, 0, 2)
+		ZEND_ARG_INFO(0, key)
+		ZEND_ARG_INFO(0, value)
+	ZEND_END_ARG_INFO()
+
+	ZEND_BEGIN_ARG_INFO_EX(imagick_getregistry_args, 0, 0, 1)
+		ZEND_ARG_INFO(0, key)
+	ZEND_END_ARG_INFO()
+
 /* ImagickDraw */
 #if MagickLibVersion > 0x649
 	ZEND_BEGIN_ARG_INFO_EX(imagickdraw_settextkerning_args, 0, 0, 1)
@@ -2505,6 +2514,9 @@ static zend_function_entry php_imagick_class_methods[] =
 #if MagickLibVersion >= 0x652
 	PHP_ME(imagick, subimagematch, imagick_subimagematch_args, ZEND_ACC_PUBLIC)
 #endif
+	PHP_ME(imagick, setregistry, imagick_setregistry_args, ZEND_ACC_STATIC|ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getregistry, imagick_getregistry_args, ZEND_ACC_STATIC|ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, listregistry, imagick_zero_args, ZEND_ACC_STATIC|ZEND_ACC_PUBLIC)
 	{ NULL, NULL, NULL }
 };
 

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -11419,4 +11419,80 @@ PHP_METHOD(imagick, subimagematch)
 #endif
 
 
+/* {{{ proto array Imagick::setRegistry(string key, string value)
+	Sets the ImageMagick registry entry named key to value. This is most
+	useful for setting "temporary-path" which controls where ImageMagick
+	creates temporary images e.g. while processing PDFs.
+*/
+PHP_METHOD(imagick, setregistry)
+{
+	MagickBooleanType status;
+	char *key, *value;
+	int key_len, value_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &key, &key_len, &value, &value_len) == FAILURE) {
+		return;
+	}
+
+	status = SetImageRegistry(StringRegistryType, key, value, NULL);
+
+	/* No magick is going to happen */
+	if (status == MagickFalse) {
+		RETURN_FALSE;
+	}
+
+	RETURN_TRUE;
+}
+/* }}} */
+
+
+/* {{{ proto array Imagick::getRegistry(string key)
+	Get the StringRegistry entry for the named key or false if not set.
+*/
+PHP_METHOD(imagick, getregistry)
+{
+	MagickBooleanType status;
+	char *key, *value;
+	int key_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
+		return;
+	}
+
+	value = GetImageRegistry(StringRegistryType, key, NULL);
+
+	if (value != NULL) {
+		ZVAL_STRING(return_value, (char *)value, 1);
+		IMAGICK_FREE_MAGICK_MEMORY(value);
+		return;
+	}
+
+	RETURN_FALSE;
+}
+/* }}} */
+
+
+/* {{{ proto array Imagick::setRegistry()
+	List all the registry settings calls GetImageRegistry. returns an array of all the key/value pairs in the registry 
+*/
+PHP_METHOD(imagick, listregistry)
+{
+	char *registry = NULL;
+	char *value = NULL;
+
+	array_init(return_value);
+
+	ResetImageRegistryIterator();
+	while (registry = GetNextImageRegistry()) {
+		value = GetImageRegistry(StringRegistryType, registry, NULL);
+		//should this be add_assoc_string(return_value, estrdup(registry), value, 1);
+		add_assoc_string(return_value, registry, value, 1);
+		IMAGICK_FREE_MAGICK_MEMORY(value);
+	}
+
+	return;
+}
+/* }}} */
+
+
 /* end of Imagick */

--- a/php_imagick_defs.h
+++ b/php_imagick_defs.h
@@ -608,6 +608,9 @@ PHP_METHOD(imagick, statisticimage);
 PHP_METHOD(imagick, subimagematch);
 #endif
 
+PHP_METHOD(imagick, setregistry);
+PHP_METHOD(imagick, getregistry);
+PHP_METHOD(imagick, listregistry);
 
 /* Forward declarations (ImagickDraw) */
 #if MagickLibVersion > 0x628


### PR DESCRIPTION
These are required to set which directory ImageMagick uses as a temp directory.

I think it's much better to add these rather than trying to set the directory through an ini file setting as:

* ini settings generally suck in general, but particular as if something goes wrong there's no good way to debug it.
* It allows users of Imagick to set the temp directory programmatically rather than just being a single possible temp dir.
* It allows switching of temp dir at run time - e.g. if a single image process is running into problems, you could switch the temp dir for just that image manipulation. 