### PR TITLE
Fix VC11 errors

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -7856,9 +7856,6 @@ void s_add_named_strings (zval *array, const char *haystack TSRMLS_DC)
 	char *line;
 #endif
 
-	found = 0;
-
-
 	const char *str_keys [] = {
 		"Format: ",
 		"Units: ",
@@ -7876,6 +7873,9 @@ void s_add_named_strings (zval *array, const char *haystack TSRMLS_DC)
 		"fileSize",
 		"compression"
 	};
+
+	found = 0;
+
 
 	buffer = estrdup (haystack);
 


### PR DESCRIPTION
The declarations of str_keys and arr_keys have to be before 'found = 0'.