### PR TITLE
Support pkg-config

### DIFF
--- a/imagemagick.m4
+++ b/imagemagick.m4
@@ -9,6 +9,7 @@
 #  IM_IMAGEMAGICK_PREFIX
 #  IM_IMAGEMAGICK_VERSION
 #  IM_IMAGEMAGICK_VERSION_MASK
+#  IM_USE_PKG_CONFIG
 #
 # Usage:
 #   IM_FIND_IMAGEMAGICK (MINIMUM_VERSION, EXTRA_SEARCH_PREFIX)
@@ -71,8 +72,14 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
     done
   fi
 
+  IM_USE_PKG_CONFIG=0
   if test "x" = "x$IM_WAND_BINARY"; then
-    AC_MSG_ERROR(not found. Please provide a path to MagickWand-config or Wand-config program.)
+    if eval '$PKG_CONFIG --exists MagickWand'; then
+      IM_USE_PKG_CONFIG=1
+      IM_WAND_BINARY=$PKG_CONFIG
+    else
+      AC_MSG_ERROR(not found. Please provide a path to MagickWand-config or Wand-config program.)
+    fi
   fi
   AC_MSG_RESULT([found in $IM_WAND_BINARY])
 
@@ -81,7 +88,11 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
   
 # Check version
 #
-  IM_IMAGEMAGICK_VERSION=`$IM_WAND_BINARY --version`
+  if test "$IM_USE_PKG_CONFIG" = "1"; then
+    IM_IMAGEMAGICK_VERSION=`$IM_WAND_BINARY --modversion MagickWand`
+  else
+    IM_IMAGEMAGICK_VERSION=`$IM_WAND_BINARY --version`
+  fi
   IM_IMAGEMAGICK_VERSION_MASK=`echo $IM_IMAGEMAGICK_VERSION | $AWK 'BEGIN { FS = "."; } { printf "%d", ($[1] * 1000 + $[2]) * 1000 + $[3];}'`
 
   IM_MIMIMUM_VERSION_MASK=`echo $IM_MINIMUM_VERSION | $AWK 'BEGIN { FS = "."; } { printf "%d", ($[1] * 1000 + $[2]) * 1000 + $[3];}'`
@@ -101,7 +112,11 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
 
   AC_MSG_CHECKING(for MagickWand.h or magick-wand.h header)
 
-  IM_PREFIX=`$IM_WAND_BINARY --prefix`
+  if test "$IM_USE_PKG_CONFIG" = "1"; then
+    IM_PREFIX=`$IM_WAND_BINARY --variable prefix MagickWand`
+  else
+    IM_PREFIX=`$IM_WAND_BINARY --prefix`
+  fi
   IM_MAJOR_VERSION=`echo $IM_IMAGEMAGICK_VERSION | $AWK 'BEGIN { FS = "."; } {print $[1]}'`
 
   # Try the header formats from newest to oldest
@@ -152,15 +167,20 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
 #
 # The cflags and libs
 #
-  IM_IMAGEMAGICK_LIBS=`$IM_WAND_BINARY --libs`
-  IM_IMAGEMAGICK_CFLAGS=`$IM_WAND_BINARY --cflags`
-
+  if test "$IM_USE_PKG_CONFIG" = "1"; then
+    IM_IMAGEMAGICK_LIBS=`$IM_WAND_BINARY --libs MagickWand`
+    IM_IMAGEMAGICK_CFLAGS=`$IM_WAND_BINARY --cflags MagickWand`
+  else
+    IM_IMAGEMAGICK_LIBS=`$IM_WAND_BINARY --libs`
+    IM_IMAGEMAGICK_CFLAGS=`$IM_WAND_BINARY --cflags`
+  fi
   export IM_IMAGEMAGICK_PREFIX
   export IM_WAND_BINARY
   export IM_IMAGEMAGICK_VERSION
   export IM_IMAGEMAGICK_VERSION_MASK
   export IM_INCLUDE_FORMAT
   export IM_HEADER_STYLE
+  export IM_USE_PKG_CONFIG
 
   export IM_IMAGEMAGICK_LIBS
   export IM_IMAGEMAGICK_CFLAGS


### PR DESCRIPTION
Debian 8 (Jessie) has this in its imagemagick changelog:

```
imagemagick (8:6.8.9.9-1) unstable; urgency=high

  Obsolete config scripts (Magick-config, MagickCore-config,
  MagickWand-config, Wand-config and Magick++-config) are
  not multi-arch safe and thus have been removed from /usr/bin.
  .
  Moreover, these scripts are superseded by pkg-config
  facilities.
  .
  However as a courtesy to our users, these scripts have
  been moved to
  /usr/lib/$DEB_HOST_MULTIARCH/ImageMagick-$VERSION/bin-$QUANTUMDEPTH/
  where $DEB_HOST_MULTIARCH is the multi-arch triplet and
  $QUANTUMDEPTH is the current quantum depth. $VERSION is the upstream
  version without the revision number.
  .
  Please note that these scripts will be definitively removed after
  jessie.

 -- Bastien Roucariès <roucaries.bastien+debian@gmail.com>  Sun, 19 Oct 2014 12:12:20 +0200
```

This PR adds support for getting the same information from pkg-config if MagickWand is known to it.