### PR TITLE
report headers and library version

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -3225,7 +3225,10 @@ PHP_MINFO_FUNCTION(imagick)
 #else
 	php_info_print_table_row(2, "imagick classes", "Imagick, ImagickDraw, ImagickPixel, ImagickPixelIterator");
 #endif
-	php_info_print_table_row(2, "ImageMagick version", MagickGetVersion(&version_number));
+#ifdef MagickVersion
+	php_info_print_table_row(2, "ImageMagick headers version", MagickVersion);
+#endif
+	php_info_print_table_row(2, "ImageMagick library version", MagickGetVersion(&version_number));
 	php_info_print_table_row(2, "ImageMagick copyright", MagickGetCopyright());
 	php_info_print_table_row(2, "ImageMagick release date", MagickGetReleaseDate());
 	php_info_print_table_row(2, "ImageMagick number of supported formats: ", buffer);


### PR DESCRIPTION
Sometime both version can differ (after an update of the library)
* headers version = buildtime
* library verison = runtime

     ImageMagick headers version => ImageMagick 6.9.1-2 Q16 x86_64 2015-05-28 http://www.imagemagick.org
     ImageMagick library version => ImageMagick 6.9.1-3 Q16 x86_64 2015-05-28 http://www.imagemagick.org
