### PR TITLE
Rounding fix for cropThumbnailImage

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -7144,10 +7144,10 @@ zend_bool s_crop_thumbnail_image(MagickWand *magick_wand, long desired_width, lo
 
 	if (ratio_x > ratio_y) {
 		new_width  = desired_width;
-		new_height = ratio_x * (double)orig_height;
+		new_height = ceil(ratio_x * (double)orig_height);
 	} else {
 		new_height = desired_height;
-		new_width  = ratio_y * (double)orig_width;
+		new_width  = ceil(ratio_y * (double)orig_width);
 	}
 
 	if (MagickThumbnailImage(magick_wand, new_width, new_height) == MagickFalse) {

--- a/tests/ceil.phpt
+++ b/tests/ceil.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test for round issues
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$imagick = new Imagick();
+$imagick->newImage(1128, 1128, '#dddddd', 'jpg' );
+$imagick->cropThumbnailImage(250, 250);
+
+$size = $imagick->getImageGeometry();
+
+var_dump($size);
+
+?>
+--EXPECTF--
+array(2) {
+  ["width"]=>
+  int(250)
+  ["height"]=>
+  int(250)
+}


### PR DESCRIPTION
Hello,

we encountered an issue with the calculation of "cropThumbnailImage", we were expecting e.g. 250x250 images but sometimes we were getting 249x250. I found out that in some cases the rounding is not accurate. In our example it was "249,999768". For my understanding it is enough to add "ceil" to round the value to the next number. I did some tests with random values for width / height and it never failed with the fix.

I modified only "imagick_class.c"  and i have added one test file to confirm that it's working as expected. You can also run my test against the current version, it will fail with "width 249" instead of 250.

Please let me know if i missed something.

Michael