### PR TITLE
deprecate methods not available in IM 7, see #162

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -2047,7 +2047,7 @@ static zend_function_entry php_imagickdraw_class_methods[] =
 #if MagickLibVersion >= 0x700
 	PHP_ME(imagickdraw, alpha, imagickdraw_matte_args, ZEND_ACC_PUBLIC)
 #else
-	PHP_ME(imagickdraw, matte, imagickdraw_matte_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagickdraw, matte, imagickdraw_matte_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 	PHP_ME(imagickdraw, polygon, imagickdraw_polygon_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagickdraw, point, imagickdraw_point_args, ZEND_ACC_PUBLIC)
@@ -2249,7 +2249,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, uniqueimagecolors, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, getimagematte, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getimagematte, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, setimagematte, imagick_setimagematte_args, ZEND_ACC_PUBLIC)
@@ -2263,22 +2263,22 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, adaptivesharpenimage, imagick_adaptivesharpenimage_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, randomthresholdimage, imagick_randomthresholdimage_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, roundcornersimage, imagick_roundcornersimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, roundcornersimage, imagick_roundcornersimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 	/* This alias is due to BWC */
-	PHP_MALIAS(imagick, roundcorners, roundcornersimage, imagick_roundcornersimage_args, ZEND_ACC_PUBLIC)
+	PHP_MALIAS(imagick, roundcorners, roundcornersimage, imagick_roundcornersimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 	PHP_ME(imagick, setiteratorindex, imagick_setiteratorindex_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, getiteratorindex, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, transformimage, imagick_transformimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, transformimage, imagick_transformimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 #if MagickLibVersion > 0x630
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, setimageopacity, imagick_setimageopacity_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, setimageopacity, imagick_setimageopacity_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, orderedposterizeimage, imagick_orderedposterizeimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, orderedposterizeimage, imagick_orderedposterizeimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif //#if MagickLibVersion < 0x700
 #endif //#if MagickLibVersion > 0x630
 #if MagickLibVersion > 0x631
@@ -2302,7 +2302,7 @@ static zend_function_entry php_imagick_class_methods[] =
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion > 0x634
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, paintfloodfillimage, imagick_paintfloodfillimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, paintfloodfillimage, imagick_paintfloodfillimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 #endif
@@ -2315,13 +2315,13 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, writeimagesfile, imagick_writeimagesfile_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, resetimagepage, imagick_resetimagepage_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, setimageclipmask, imagick_setimageclipmask_args, ZEND_ACC_PUBLIC)
-	PHP_ME(imagick, getimageclipmask, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, setimageclipmask, imagick_setimageclipmask_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+	PHP_ME(imagick, getimageclipmask, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 	PHP_ME(imagick, animateimages, imagick_animateimages_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, recolorimage, imagick_recolorimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, recolorimage, imagick_recolorimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 #endif
@@ -2420,7 +2420,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, clone, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, getimagesize, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getimagesize, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, getimageblob, imagick_zero_args, ZEND_ACC_PUBLIC)
@@ -2434,8 +2434,8 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, hasnextimage, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, setimageindex, imagick_setimageindex_args, ZEND_ACC_PUBLIC)
-	PHP_ME(imagick, getimageindex, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, setimageindex, imagick_setimageindex_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+	PHP_ME(imagick, getimageindex, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, commentimage, imagick_commentimage_args, ZEND_ACC_PUBLIC)
@@ -2464,7 +2464,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, posterizeimage, imagick_posterizeimage_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, radialblurimage, imagick_radialblurimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, radialblurimage, imagick_radialblurimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 	PHP_ME(imagick, raiseimage, imagick_raiseimage_args, ZEND_ACC_PUBLIC)
@@ -2477,7 +2477,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, shadowimage, imagick_shadowimage_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, setimageattribute, imagick_setimageattribute_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, setimageattribute, imagick_setimageattribute_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, setimagebackgroundcolor, imagick_setimagebackgroundcolor_args, ZEND_ACC_PUBLIC)
@@ -2490,7 +2490,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, setimagegamma, imagick_setimagegamma_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, setimageiterations, imagick_setimageiterations_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, setimagemattecolor, imagick_setimagemattecolor_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, setimagemattecolor, imagick_setimagemattecolor_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 	PHP_ME(imagick, setimagepage, imagick_setimagepage_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, setimageprogressmonitor, imagick_setimageprogressmonitor_args, ZEND_ACC_PUBLIC)
@@ -2521,7 +2521,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, motionblurimage, imagick_motionblurimage_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-	PHP_ME(imagick, mosaicimages, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, mosaicimages, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 	PHP_ME(imagick, morphimages, imagick_morphimages_args, ZEND_ACC_PUBLIC)
@@ -2529,7 +2529,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, affinetransformimage, imagick_affinetransformimage_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-	PHP_ME(imagick, averageimages, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, averageimages, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 	PHP_ME(imagick, borderimage, imagick_borderimage_args, ZEND_ACC_PUBLIC)
@@ -2542,7 +2542,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, coalesceimages, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, colorfloodfillimage, imagick_colorfloodfillimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, colorfloodfillimage, imagick_colorfloodfillimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, colorizeimage, imagick_colorizeimage_args, ZEND_ACC_PUBLIC)
@@ -2564,7 +2564,7 @@ static zend_function_entry php_imagick_class_methods[] =
 #endif // MagickLibVersion >= 0x687
 #if MagickLibVersion < 0x700
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-	PHP_ME(imagick, flattenimages, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, flattenimages, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 	PHP_ME(imagick, flipimage, imagick_zero_args, ZEND_ACC_PUBLIC)
@@ -2578,7 +2578,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, gaussianblurimage, imagick_gaussianblurimage_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-	PHP_ME(imagick, getimageattribute, imagick_getimageattribute_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getimageattribute, imagick_getimageattribute_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 	PHP_ME(imagick, getimagebackgroundcolor, imagick_zero_args, ZEND_ACC_PUBLIC)
@@ -2588,7 +2588,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, getimagechanneldistortion, imagick_getimagechanneldistortion_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, getimagechannelextrema, imagick_getimagechannelextrema_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getimagechannelextrema, imagick_getimagechannelextrema_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, getimagechannelmean, imagick_getimagechannelmean_args, ZEND_ACC_PUBLIC)
@@ -2601,7 +2601,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, getimagedistortion, imagick_getimagedistortion_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, getimageextrema, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getimageextrema, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, getimagedispose, imagick_zero_args, ZEND_ACC_PUBLIC)
@@ -2612,7 +2612,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, getimageinterlacescheme, imagick_zero_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, getimageiterations, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, getimagemattecolor, imagick_zero_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getimagemattecolor, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif //#if MagickLibVersion < 0x700
 	PHP_ME(imagick, getimagepage, imagick_zero_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, getimagepixelcolor, imagick_getimagepixelcolor_args, ZEND_ACC_PUBLIC)
@@ -2639,20 +2639,20 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, magnifyimage, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, mapimage, imagick_mapimage_args, ZEND_ACC_PUBLIC)
-	PHP_ME(imagick, mattefloodfillimage, imagick_mattefloodfillimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, mapimage, imagick_mapimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+	PHP_ME(imagick, mattefloodfillimage, imagick_mattefloodfillimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 #if MagickLibVersion < 0x700
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-	PHP_ME(imagick, medianfilterimage, imagick_medianfilterimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, medianfilterimage, imagick_medianfilterimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 	PHP_ME(imagick, negateimage, imagick_negateimage_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, paintopaqueimage, imagick_paintopaqueimage_args, ZEND_ACC_PUBLIC)
-	PHP_ME(imagick, painttransparentimage, imagick_painttransparentimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, paintopaqueimage, imagick_paintopaqueimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+	PHP_ME(imagick, painttransparentimage, imagick_painttransparentimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif //#if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, previewimages, imagick_previewimages_args, ZEND_ACC_PUBLIC)
@@ -2661,15 +2661,15 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, quantizeimages, imagick_quantizeimages_args, ZEND_ACC_PUBLIC)
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, reducenoiseimage, imagick_reducenoiseimage_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, reducenoiseimage, imagick_reducenoiseimage_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 #endif
 	PHP_ME(imagick, removeimageprofile, imagick_removeimageprofile_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, separateimagechannel, imagick_separateimagechannel_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, sepiatoneimage, imagick_sepiatoneimage_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, setimagebias, imagick_setimagebias_args, ZEND_ACC_PUBLIC)
-	PHP_ME(imagick, setimagebiasquantum, imagick_setimagebiasquantum_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, setimagebias, imagick_setimagebias_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+	PHP_ME(imagick, setimagebiasquantum, imagick_setimagebiasquantum_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif
 	PHP_ME(imagick, setimageblueprimary, imagick_setimageblueprimary_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, setimagebordercolor, imagick_setimagebordercolor_args, ZEND_ACC_PUBLIC)
@@ -2768,7 +2768,7 @@ static zend_function_entry php_imagick_class_methods[] =
 #if MagickLibVersion >= 0x680
 	PHP_ME(imagick, morphology, imagick_morphology_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700
-	PHP_ME(imagick, filter, imagick_filter_args, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, filter, imagick_filter_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
 #endif // #if MagickLibVersion < 0x700
 #endif
 	PHP_ME(imagick, setantialias, imagick_setantialias_args, ZEND_ACC_PUBLIC)

--- a/tests/047_Imagick_convolveImage_6.phpt
+++ b/tests/047_Imagick_convolveImage_6.phpt
@@ -38,4 +38,5 @@ convolveImage($bias, $kernelMatrix) ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::setimagebias() is deprecated in %s
 Ok

--- a/tests/098_Imagick_orderedPosterizeImage_basic.phpt
+++ b/tests/098_Imagick_orderedPosterizeImage_basic.phpt
@@ -28,4 +28,5 @@ orderedPosterizeImage($orderedPosterizeType) ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::orderedposterizeimage() is deprecated in %S
 Ok

--- a/tests/102_Imagick_radialBlurImage_basic.phpt
+++ b/tests/102_Imagick_radialBlurImage_basic.phpt
@@ -24,4 +24,9 @@ radialBlurImage() ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::radialblurimage() is deprecated in %s
+
+Deprecated: Function Imagick::radialblurimage() is deprecated in %s
+
+Deprecated: Function Imagick::radialblurimage() is deprecated in %s
 Ok

--- a/tests/112_Imagick_roundCorners_basic.phpt
+++ b/tests/112_Imagick_roundCorners_basic.phpt
@@ -40,4 +40,5 @@ roundCorners() ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::roundcornersimage() is deprecated in %s
 Ok

--- a/tests/121_Imagick_setImageBias_basic.phpt
+++ b/tests/121_Imagick_setImageBias_basic.phpt
@@ -35,4 +35,7 @@ setImageBias($bias) ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::setimagebias() is deprecated in %s
+
+Warning: Cannot modify header information - headers already sent by %s
 Ok

--- a/tests/123_Imagick_setImageClipMask_basic.phpt
+++ b/tests/123_Imagick_setImageClipMask_basic.phpt
@@ -48,4 +48,5 @@ setImageClipMask() ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::setimageclipmask() is deprecated in %s
 Ok

--- a/tests/159_Imagick_transformImage_basic.phpt
+++ b/tests/159_Imagick_transformImage_basic.phpt
@@ -22,4 +22,5 @@ transformimage() ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::transformimage() is deprecated in %s
 Ok

--- a/tests/180_ImagickDraw_matte_basic.phpt
+++ b/tests/180_ImagickDraw_matte_basic.phpt
@@ -41,4 +41,5 @@ matte($strokeColor, $fillColor, $backgroundColor, $paintType) ;
 echo "Ok";
 ?>
 --EXPECTF--
+Deprecated: Function ImagickDraw::matte() is deprecated in %s
 Ok

--- a/tests/bug20636.phpt
+++ b/tests/bug20636.phpt
@@ -27,4 +27,5 @@ try {
 
 ?>
 --EXPECTF--
+Deprecated: Function Imagick::roundcorners() is deprecated in %s
 success


### PR DESCRIPTION
Is it the expected part for #162 ?

If ok, I can probably add some "deprecation" information in PHP manual, such as:

> This method is only available with ImageMagick library version 6.
> Since 3.4.3 this method is deprecated.
> 
