### PR TITLE
Raise required php version to 5.3.2

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -18,7 +18,7 @@ IM_FIND_IMAGEMAGICK([6.2.4], [$PHP_IMAGICK])
 #
 # PHP minimum version
 #
-  AC_MSG_CHECKING([PHP version is at least 5.1.3])
+  AC_MSG_CHECKING([PHP version is at least 5.3.2])
 
   if test -z "${PHP_VERSION_ID}"; then
     if test -z "${PHP_CONFIG}"; then
@@ -34,7 +34,7 @@ IM_FIND_IMAGEMAGICK([6.2.4], [$PHP_IMAGICK])
     PHP_IMAGICK_FOUND_VERSION="${PHP_VERSION}"
   fi
 
-  if test "$PHP_IMAGICK_FOUND_VERNUM" -ge "50103"; then
+  if test "$PHP_IMAGICK_FOUND_VERNUM" -ge "50302"; then
     AC_MSG_RESULT(yes. found $PHP_IMAGICK_FOUND_VERSION)
   else 
     AC_MSG_ERROR(no. found $PHP_IMAGICK_FOUND_VERSION)


### PR DESCRIPTION
First *stable* version available in Ubuntu Lucid
In Debian Squeezy was 5.3.3

For issue #192 