### PR TITLE
Call it "ImageMagick" everywhere

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,5 +1,5 @@
 PHP_ARG_WITH(imagick, whether to enable the imagick extension,
-[ --with-imagick[=DIR]	Enables the imagick extension. DIR is the prefix to Imagemagick installation directory.], no)
+[ --with-imagick[=DIR]	Enables the imagick extension. DIR is the prefix to ImageMagick installation directory.], no)
 
 
 if test $PHP_IMAGICK != "no"; then

--- a/examples/polygon.php
+++ b/examples/polygon.php
@@ -1,6 +1,6 @@
 <?php
 /*
-	This examples was ported from Imagemagick C examples.
+	This examples was ported from ImageMagick C examples.
 */
 
 /* Create Imagick objects */

--- a/imagemagick.m4
+++ b/imagemagick.m4
@@ -140,7 +140,7 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
   if test "$IM_IMAGEMAGICK_VERSION_MASK" -ge $IM_MIMIMUM_VERSION_MASK; then
     AC_MSG_RESULT(found version $IM_IMAGEMAGICK_VERSION)
   else
-    AC_MSG_ERROR(no. You need at least Imagemagick version $IM_MINIMUM_VERSION to use this extension.)
+    AC_MSG_ERROR(no. You need at least ImageMagick version $IM_MINIMUM_VERSION to use this extension.)
   fi
 
 # Potential locations for the header

--- a/imagick.c
+++ b/imagick.c
@@ -3525,7 +3525,7 @@ static void checkImagickVersion()
 	//This gets the version that Imagick was compiled against.
 	size_t imagickVersion = MagickLibVersion;
 
-	//This gets the version of Image Magick that has been loaded
+	//This gets the version of ImageMagick that has been loaded
 	size_t imageMagickLibraryVersion;
 
 	GetMagickVersion(&imageMagickLibraryVersion);
@@ -3536,7 +3536,7 @@ static void checkImagickVersion()
 
 	zend_error(
 		E_WARNING,
-		"Version warning: Imagick was compiled against Image Magick version %lu but version %lu is loaded. Imagick will run but may behave surprisingly",
+		"Version warning: Imagick was compiled against ImageMagick version %lu but version %lu is loaded. Imagick will run but may behave surprisingly",
 		(unsigned long)imagickVersion,
 		(unsigned long)imageMagickLibraryVersion
 	);

--- a/imagick.c
+++ b/imagick.c
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/imagick_file.c
+++ b/imagick_file.c
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick											  |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar				  |
-   | Imagemagick (c) ImageMagick Studio LLC								  |
+   | ImageMagick (c) ImageMagick Studio LLC								  |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,	  |
    | that is bundled with this package in the file LICENSE, and is		  |

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -719,7 +719,7 @@ void s_convert_exception (char *description, const char *default_message, long s
 }
 
 /**
-	Convert image magick MagickWand exception to PHP exception
+	Convert ImageMagick MagickWand exception to PHP exception
 */
 void php_imagick_convert_imagick_exception (MagickWand *magick_wand, const char *default_message TSRMLS_DC)
 {

--- a/imagickdraw_class.c
+++ b/imagickdraw_class.c
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/imagickpixel_class.c
+++ b/imagickpixel_class.c
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/imagickpixeliterator_class.c
+++ b/imagickpixeliterator_class.c
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/package.xml
+++ b/package.xml
@@ -360,6 +360,6 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 	</dependencies>
 	<providesextension>imagick</providesextension>
 	<extsrcrelease>
-  		<configureoption default="autodetect" name="with-imagick" prompt="Please provide the prefix of Imagemagick installation" />
+  		<configureoption default="autodetect" name="with-imagick" prompt="Please provide the prefix of ImageMagick installation" />
  	</extsrcrelease>
 </package>

--- a/php_imagick.h
+++ b/php_imagick.h
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/php_imagick_defs.h
+++ b/php_imagick_defs.h
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/php_imagick_file.h
+++ b/php_imagick_file.h
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/php_imagick_helpers.h
+++ b/php_imagick_helpers.h
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/php_imagick_macros.h
+++ b/php_imagick_macros.h
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/php_imagick_shared.h
+++ b/php_imagick_shared.h
@@ -3,7 +3,7 @@
    | PHP Version 5 / Imagick	                                          |
    +----------------------------------------------------------------------+
    | Copyright (c) 2006-2013 Mikko Koppanen, Scott MacVicar               |
-   | Imagemagick (c) ImageMagick Studio LLC                               |
+   | ImageMagick (c) ImageMagick Studio LLC                               |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |


### PR DESCRIPTION
This pull request changes various incorrect representations of the name "ImageMagick" to the correct one.