### PR TITLE
Wrong class mentioned in the Changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,7 +63,7 @@
   * Prevent attempts to resize image to zero width or height, which is not supported by ImageMagick.
   * Fix compiling on Windows issue.
 - Added:
-  * function Imagick::setImageAlpha() which replaces Imagick::setOpacity()
+  * function Imagick::setImageAlpha() which replaces ImagickDraw::setOpacity()
 
 3.4.3RC1
 - Fixes:


### PR DESCRIPTION
Wrong class is used in the Changelog. ImagickDraw only has setOpacity, there is no setOpacity in Imagick class.