### PR TITLE
Fix ImageMagick 7 support and datatypes on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,13 +1,20 @@
 ARG_WITH("imagick", "ImageMagick support", "no");
 
 if (PHP_IMAGICK != "no") {
-
-	if (CHECK_HEADER_ADD_INCLUDE("wand/MagickWand.h", "CFLAGS_IMAGICK", PHP_PHP_BUILD + "\\include\\imagemagick;" + PHP_IMAGICK)
+	var conf_ok = false;
+	if (CHECK_HEADER_ADD_INCLUDE("MagickWand/MagickWand.h", "CFLAGS_IMAGICK", PHP_PHP_BUILD + "\\include\\imagemagick;" + PHP_IMAGICK)
+			&& CHECK_LIB("CORE_RL_MagickWand_.lib", "imagick", PHP_PHP_BUILD + "\\lib\\imagemagick;" + PHP_IMAGICK)
+			&& CHECK_LIB("CORE_RL_MagickCore_.lib", "imagick", PHP_PHP_BUILD + "\\lib\\imagemagick;" + PHP_IMAGICK)) {
+		ADD_FLAG("CFLAGS_IMAGICK", "/D IM_MAGICKWAND_HEADER_STYLE_SEVEN /D IMAGICK_USE_NEW_HEADER /D _MAGICKMOD_ /D _VISUALC_ /D NeedFunctionPrototypes /D _LIB");
+		conf_ok = true;
+	} else if (CHECK_HEADER_ADD_INCLUDE("wand/MagickWand.h", "CFLAGS_IMAGICK", PHP_PHP_BUILD + "\\include\\imagemagick;" + PHP_IMAGICK)
 			&& CHECK_LIB("CORE_RL_wand_.lib", "imagick", PHP_PHP_BUILD + "\\lib\\imagemagick;" + PHP_IMAGICK)
-			&& CHECK_LIB("CORE_RL_magick_.lib", "imagick", PHP_PHP_BUILD + "\\lib\\imagemagick;" + PHP_IMAGICK)
-			)
-	{
+			&& CHECK_LIB("CORE_RL_magick_.lib", "imagick", PHP_PHP_BUILD + "\\lib\\imagemagick;" + PHP_IMAGICK)) {
 		ADD_FLAG("CFLAGS_IMAGICK", "/D IMAGICK_USE_NEW_HEADER /D _MAGICKMOD_ /D _VISUALC_ /D NeedFunctionPrototypes /D _LIB");
+		conf_ok = true;
+	}
+
+	if (conf_ok) {
 		EXTENSION('imagick', 'imagick_class.c imagickdraw_class.c imagickpixel_class.c imagickpixeliterator_class.c imagick_helpers.c imagick_file.c imagick.c imagickkernel_class.c shim_im6_to_im7.c');
 		AC_DEFINE('HAVE_IMAGICK', 1);
 		AC_DEFINE('IMAGICK_EXPORTS', 1);

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -2369,7 +2369,7 @@ PHP_METHOD(imagick, setimagegravity)
 PHP_METHOD(imagick, importimagepixels) 
 {
 	double        *double_array;
-	long          *long_array;
+	im_long       *long_array;
 	unsigned char *char_array;
 
 	php_imagick_object *intern;
@@ -7722,10 +7722,10 @@ PHP_METHOD(imagick, getnumberimages)
 */
 #if MagickLibVersion > 0x631
 static
-zend_bool s_resize_bounding_box(MagickWand *magick_wand, long box_width, long box_height, zend_bool fill, zend_bool legacy)
+zend_bool s_resize_bounding_box(MagickWand *magick_wand, im_long box_width, im_long box_height, zend_bool fill, zend_bool legacy)
 {
-	long new_width, new_height;
-	long extent_x, extent_y;
+	im_long new_width, new_height;
+	im_long extent_x, extent_y;
 
 	/* Calculate dimensions */
 	if (!php_imagick_thumbnail_dimensions(magick_wand, 1, box_width, box_height, &new_width, &new_height, legacy)) {

--- a/imagick_file.c
+++ b/imagick_file.c
@@ -161,7 +161,7 @@ int php_imagick_read_image_using_imagemagick(php_imagick_object *intern, struct 
 {
 	if (type == ImagickReadImage) {
 		if (MagickReadImage(intern->magick_wand, file->filename) == MagickFalse) {
-			struct stat st;
+			zend_stat_t st;
 			/* Resolved to a filename. Check that it's not a dir */
 			if (php_sys_stat(file->absolute_path, &st) == 0 && S_ISDIR(st.st_mode)) {
 				return IMAGICK_RW_PATH_IS_DIR;

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -331,10 +331,10 @@ double *php_imagick_zval_to_double_array(zval *param_array, im_long *num_element
 	return double_array;
 }
 
-long *php_imagick_zval_to_long_array(zval *param_array, long *num_elements TSRMLS_DC)
+im_long *php_imagick_zval_to_long_array(zval *param_array, im_long *num_elements TSRMLS_DC)
 {
-	long *long_array;
-	long i = 0;
+	im_long *long_array;
+	im_long i = 0;
 
 #ifdef ZEND_ENGINE_3
 	zval *pzvalue;
@@ -348,7 +348,7 @@ long *php_imagick_zval_to_long_array(zval *param_array, long *num_elements TSRML
 		return NULL;
 	}
 
-	long_array = ecalloc(*num_elements, sizeof(long));
+	long_array = ecalloc(*num_elements, sizeof(im_long));
 
 #ifdef ZEND_ENGINE_3
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(param_array), pzvalue) {
@@ -362,7 +362,7 @@ long *php_imagick_zval_to_long_array(zval *param_array, long *num_elements TSRML
 			zend_hash_move_forward(Z_ARRVAL_P(param_array)), i++)
 	{
 		zval tmp_zval, *tmp_pzval;
- 		long value = 0;
+ 		im_long value = 0;
 
 		if (Z_TYPE_PP(ppzval) == IS_DOUBLE) {
 			value = Z_LVAL_PP(ppzval);
@@ -383,10 +383,10 @@ long *php_imagick_zval_to_long_array(zval *param_array, long *num_elements TSRML
 	return long_array;
 }
 
-unsigned char *php_imagick_zval_to_char_array(zval *param_array, long *num_elements TSRMLS_DC)
+unsigned char *php_imagick_zval_to_char_array(zval *param_array, im_long *num_elements TSRMLS_DC)
 {
 	unsigned char *char_array;
-	long i = 0;
+	im_long i = 0;
 
 #ifdef ZEND_ENGINE_3
 	zval *pzvalue;
@@ -414,7 +414,7 @@ unsigned char *php_imagick_zval_to_char_array(zval *param_array, long *num_eleme
 			zend_hash_move_forward(Z_ARRVAL_P(param_array)), i++)
 	{
 		zval tmp_zval, *tmp_pzval;
-		long value = 0;
+		im_long value = 0;
 		if (Z_TYPE_PP(ppzval) == IS_DOUBLE) {
 			value = Z_LVAL_PP(ppzval);
 		}

--- a/imagickkernel_class.c
+++ b/imagickkernel_class.c
@@ -152,9 +152,9 @@ static KernelInfo *imagick_createKernel(KernelValueType *values, size_t width, s
 
 #if MagickLibVersion >= 0x700
 	int i;
-	ExceptionInfo *exception_info = NULL;
+	ExceptionInfo *_exception_info = (ExceptionInfo *) NULL;
 	//TODO - inspect exception info
-	kernel_info=AcquireKernelInfo(NULL, exception_info);
+	kernel_info=AcquireKernelInfo(NULL, _exception_info);
 #else
 	kernel_info=AcquireKernelInfo(NULL);
 #endif
@@ -591,7 +591,7 @@ PHP_METHOD(imagickkernel, frombuiltin)
 	IM_LEN_TYPE string_len;
 	GeometryFlags flags;
 #if MagickLibVersion >= 0x700
-	ExceptionInfo *exception_info = NULL;
+	ExceptionInfo *_exception_info = NULL;
 #endif
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ls", &kernel_type, &string, &string_len) == FAILURE) {
@@ -603,7 +603,7 @@ PHP_METHOD(imagickkernel, frombuiltin)
 	
 #if MagickLibVersion >= 0x700
 	//TODO - inspect exception info
-	kernel_info = AcquireKernelBuiltIn(kernel_type, &geometry_info, exception_info);
+	kernel_info = AcquireKernelBuiltIn(kernel_type, &geometry_info, _exception_info);
 #else
 	kernel_info = AcquireKernelBuiltIn(kernel_type, &geometry_info);
 #endif

--- a/php_imagick_helpers.h
+++ b/php_imagick_helpers.h
@@ -30,9 +30,9 @@ PointInfo *php_imagick_zval_to_pointinfo_array(zval *coordinate_array, int *num_
 
 double *php_imagick_zval_to_double_array(zval *param_array, im_long *num_elements TSRMLS_DC);
 
-long *php_imagick_zval_to_long_array(zval *param_array, long *num_elements TSRMLS_DC);
+im_long *php_imagick_zval_to_long_array(zval *param_array, im_long *num_elements TSRMLS_DC);
 
-unsigned char *php_imagick_zval_to_char_array(zval *param_array, long *num_elements TSRMLS_DC);
+unsigned char *php_imagick_zval_to_char_array(zval *param_array, im_long *num_elements TSRMLS_DC);
 
 MagickBooleanType php_imagick_progress_monitor(const char *text, const MagickOffsetType offset, const MagickSizeType span, void *client_data);
 


### PR DESCRIPTION
Things done:

- adapted config.w32, it's still compatible with lower ImageMagick versions
- fixed datatypes, almost related to incompatible pointer passing on 64-bit
- fixed symbols collisions with CRT

The PECL build host was upgraded with ImageMagick 7.0.7-11 for PHP 7.2 builds.

PR branch snapshots: http://windows.php.net/downloads/pecl/snaps/imagick/3.4.3/
ImageMagick builds: http://windows.php.net/downloads/pecl/deps/

Thanks.
