### PR TITLE
Fix broken test - sin()/cos() accept argument in radians

### DIFF
--- a/tests/031_Imagick_affineTransformImage_basic.phpt
+++ b/tests/031_Imagick_affineTransformImage_basic.phpt
@@ -14,7 +14,7 @@ function affineTransformImage() {
     $imagick->newPseudoImage(640, 480, "magick:logo");
     $draw = new \ImagickDraw();
 
-    $angle = 40 ;
+    $angle = deg2rad(40);
 
     $affineRotate = array(
         "sx" => cos($angle), "sy" => cos($angle), 


### PR DESCRIPTION
Test fails on x86 because wrong usage of argument for sin() & cos()

http://build.alpinelinux.org/buildlogs/build-edge-x86/community/php7-imagick/php7-imagick-3.4.3-r5.log